### PR TITLE
Simplifications to Body_writer.t

### DIFF
--- a/lib/client_connection.ml
+++ b/lib/client_connection.ml
@@ -88,7 +88,7 @@ module Oneshot = struct
         | `Fixed _ | `Chunked as encoding -> encoding
         | `Error _ -> assert false (* XXX(seliopou): This needs to be handled properly *)
       in
-      Body_writer.transfer_to_writer_with_encoding t.request_body ~encoding t.writer
+      Body_writer.transfer_to_writer_with_encoding t.request_body ~encoding
   ;;
 
   let set_error_and_handle_without_shutdown t error =

--- a/lib/client_connection.ml
+++ b/lib/client_connection.ml
@@ -65,9 +65,7 @@ module Oneshot = struct
     in
     let writer = Writer.create () in
     let request_body =
-      Body_writer.create (Bigstringaf.create config.request_body_buffer_size)
-        ~when_ready_to_write:(fun () ->
-          Writer.wakeup writer)
+      Body_writer.create (Bigstringaf.create config.request_body_buffer_size) writer
     in
     let t =
       { request

--- a/lib/reqd.ml
+++ b/lib/reqd.ml
@@ -255,5 +255,5 @@ let flush_response_body t =
       | `Fixed _ | `Close_delimited | `Chunked as encoding -> encoding
       | `Error _ -> assert false (* XXX(seliopou): This needs to be handled properly *)
     in
-    Body_writer.transfer_to_writer_with_encoding response_body ~encoding t.writer
+    Body_writer.transfer_to_writer_with_encoding response_body ~encoding
   | _ -> ()

--- a/lib/reqd.ml
+++ b/lib/reqd.ml
@@ -156,10 +156,7 @@ let respond_with_bigstring t response (bstr:Bigstringaf.t) =
 let unsafe_respond_with_streaming ~flush_headers_immediately t response =
   match t.response_state with
   | Waiting ->
-    let response_body =
-      Body_writer.create t.response_body_buffer ~when_ready_to_write:(fun () ->
-        Writer.wakeup t.writer)
-    in
+    let response_body = Body_writer.create t.response_body_buffer t.writer in
     Writer.write_response t.writer response;
     if t.persistent then
       t.persistent <- Response.persistent_connection response;

--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -175,10 +175,7 @@ let set_error_and_handle ?request t error =
     let writer = t.writer in
     t.error_handler ?request error (fun headers ->
       Writer.write_response writer (Response.create ~headers status);
-      let body_writer =
-        Body_writer.of_faraday (Writer.faraday writer)
-          ~when_ready_to_write:(fun () -> Writer.wakeup writer)
-      in
+      let body_writer = Body_writer.of_faraday (Writer.faraday writer) writer in
       Body.Writer body_writer);
   end
 


### PR DESCRIPTION
Simplify `Body_writer` in a couple of minor ways:

The `Writer.t` and the encoding are now passed in when creating the `Body_writer` rather than being given to `Body_writer.transfer_to_writer_with_encoding`. This makes the module a little simpler. It also deals with a couple of XXX comments -- if the encoding cannot be figured out from the provided headers, there is now a natural way to escalate that error back to the called. For example, if the user calls `Reqd.call_with_streaming` with a response that includes an invalid content length, we can raise immediately rather than raising later when we try to call `Body.transfer_to_writer_with_encoding`.

I also took the opportunity to make the `write_final_if_chunked` stuff a little simpler. Because we now know the encoding from the beginning of the lifetime of the `Body_writer`, we can have a more sensible looking type that only records that boolean if we're actually doing chunked encoding.